### PR TITLE
feat: Adding substitions input to replace values on files before sending it to the server

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,4 +6,4 @@ The document generation tool looks for files in the following locations by defau
 
 * **provider/provider.tf** example file for the provider index page
 * **data-sources/`full data source name`/data-source.tf** example file for the named data source page
-* **resources/`full resource name`/resource.tf** example file for the named data source page
+* **resources/`full resource name`/resource.tf** examples files for the named data source page

--- a/examples/resources/substitution_example/resource.tf
+++ b/examples/resources/substitution_example/resource.tf
@@ -1,0 +1,8 @@
+resource "fhirrest_fhir_resource" "patient" {
+  file_path   = "${path.cwd}/patient.json"
+  file_sha256 = sha256(file("${path.cwd}/patient.json"))
+  substitutions = {
+    "name" = "John Doe",
+    "TENANT_PLACEHOLDER" = "my-tenant",
+  }
+}


### PR DESCRIPTION
A map of substitutions to be applied to the file content before sending it to the server.
The key is the string to be replaced, and the value is the string to replace it with.
### Example:
Given a FHIR resource file with content:
```json
{
	"resourceType": "Questionnaire",
	"url": "https://system.com/R4/Questionnaire/{{Tenant.GUID}}/DiagnosticTests"
}
```

And the following substitutions:
```terraform
substitutions = {
	"{{Tenant.GUID}}" = "12345"
}
```

The final content sent to the server will be:
```json				
{
	"resourceType": "Questionnaire",
	"url": "https://system.com/R4/Questionnaire/12345/DiagnosticTests"
}
```